### PR TITLE
Changed CMT_STORE_EOS_CATEGORIZATION export to be user-generic

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -93,8 +93,8 @@ action() {
        mkdir -p "$TMPDIR"
     fi
 
-    echo "running export CMT_STORE_EOS_CATEGORIZATION=/vols/cms/khl216/cmt..."
-    export CMT_STORE_EOS_CATEGORIZATION=/vols/cms/khl216/cmt
+    echo "running export CMT_STORE_EOS_CATEGORIZATION=/vols/cms/$(whoami)/cmt..."
+    export CMT_STORE_EOS_CATEGORIZATION=/vols/cms/$(whoami)/cmt
 
     # create some dirs already
     mkdir -p "$CMT_TMP_DIR"


### PR DESCRIPTION
Changed the CMT_STORE_EOS_CATEGORIZATION export to use $(whoami) instead of khl216 as default